### PR TITLE
Update utils.py

### DIFF
--- a/erpnext_ksa/utils.py
+++ b/erpnext_ksa/utils.py
@@ -171,6 +171,6 @@ def update_itemised_tax_data(doc):
 		elif row.item_code and itemised_tax.get(row.item_code):
 			tax_rate = sum([tax.get('tax_rate', 0) for d, tax in itemised_tax.get(row.item_code).items()])
 
-		row.tax_rate = flt(tax_rate, row.precision("tax_rate"))
-		row.tax_amount = flt((row.net_amount * tax_rate) / 100, row.precision("net_amount"))
-		row.total_amount = flt((row.net_amount + row.tax_amount), row.precision("total_amount"))
+		row.tax_rate = flt(tax_rate, 2)
+		row.tax_amount = flt((row.net_amount * tax_rate) / 100,  2 )
+		row.total_amount = flt((row.net_amount + row.tax_amount), 2)


### PR DESCRIPTION
Erroe :     calculate_taxes_and_totals(self)
  File "apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 32, in __init__
    self.calculate()
  File "apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 62, in calculate
    self.set_item_wise_tax_breakup()
  File "apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 912, in set_item_wise_tax_breakup
    self.doc.other_charges_calculation = get_itemised_tax_breakup_html(self.doc)
  File "apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 959, in get_itemised_tax_breakup_html
    update_itemised_tax_data(doc)
  File "apps/erpnext/erpnext/__init__.py", line 151, in caller
    return frappe.get_attr(overrides[function_path][-1])(*args, **kwargs)
  File "apps/erpnext_ksa/erpnext_ksa/utils.py", line 174, in update_itemised_tax_data
    row.tax_rate = flt(tax_rate, row.precision("tax_rate") if row.precision("tax_rate") else 2)
  File "apps/frappe/frappe/model/base_document.py", line 1097, in precision
    if df.fieldtype in ("Currency", "Float", "Percent"):
AttributeError: 'NoneType' object has no attribute 'fieldtype'